### PR TITLE
added GEOS library for use by GDAL

### DIFF
--- a/geos/bld.bat
+++ b/geos/bld.bat
@@ -1,0 +1,11 @@
+cmake -G "NMake Makefiles" -DCMAKE_PREFIX_PATH=%PREFIX% -DCMAKE_INSTALL_PREFIX:PATH=%PREFIX% -D CMAKE_BUILD_TYPE=Release .
+if errorlevel 1 exit 1
+
+nmake
+if errorlevel 1 exit 1
+
+nmake install
+if errorlevel 1 exit 1
+
+move %PREFIX%\bin\*.* %PREFIX%
+if errorlevel 1 exit 1

--- a/geos/bld.bat
+++ b/geos/bld.bat
@@ -7,5 +7,3 @@ if errorlevel 1 exit 1
 nmake install
 if errorlevel 1 exit 1
 
-move %PREFIX%\bin\*.* %PREFIX%
-if errorlevel 1 exit 1

--- a/geos/build.sh
+++ b/geos/build.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+if [ `uname` == Darwin ]; then
+	export CC=clang
+	export CXX=clang++
+fi
+
+./configure --prefix=$PREFIX
+
+make
+make install

--- a/geos/meta.yaml
+++ b/geos/meta.yaml
@@ -1,0 +1,15 @@
+package:
+  name: geos
+  version: "3.4.2"
+
+source:
+  fn: geos-3.4.2.tar.bz2
+  url: http://download.osgeo.org/geos/geos-3.4.2.tar.bz2
+
+build:
+  number: 2
+
+about:
+  home: http://trac.osgeo.org/geos/
+  license: LGPL
+  summary: GEOS (Geometry Engine - Open Source) is a C++ port of the  Java Topology Suite (JTS).


### PR DESCRIPTION
GEOS is needed by GDAL so it can do geometry operations. This PR adds support for the GEOS library on all platforms so GDAL can be rebuilt with it in future.