### PR TITLE
Msarahan/py35

### DIFF
--- a/python-3.5/bld.bat
+++ b/python-3.5/bld.bat
@@ -1,0 +1,58 @@
+REM ========== actual compile step
+
+if "%ARCH%"=="64" (
+   set PLATFORM=x64
+) else (
+   set PLATFORM=Win32
+)
+
+msbuild PCbuild\pcbuild.sln /t:python;pythoncore;pythonw;python3dll /p:Configuration=Release /p:Platform=%PLATFORM% /m /p:OutDir=%SRC_DIR%\PCBuild\
+
+REM ========== add stuff from official python.org installer
+
+set MSI_DIR=\Pythons\3.5.0rc2-%ARCH%
+for %%x in (DLLs Doc libs tcl Tools Scripts) do (
+    xcopy /s /y %MSI_DIR%\%%x %PREFIX%\%%x\
+    if errorlevel 1 exit 1
+)
+copy %MSI_DIR%\LICENSE.txt %PREFIX%\LICENSE_PYTHON.txt
+if errorlevel 1 exit 1
+
+REM ========== add stuff from our own build
+
+xcopy /s /y %SRC_DIR%\Include %PREFIX%\include\
+if errorlevel 1 exit 1
+copy /Y %SRC_DIR%\PC\pyconfig.h %PREFIX%\include\
+if errorlevel 1 exit 1
+
+for %%x in (python35.dll python.exe pythonw.exe) do (
+    copy /Y %SRC_DIR%\PCbuild\%%x %PREFIX%
+    if errorlevel 1 exit 1
+)
+copy /Y %SRC_DIR%\PCbuild\python35.lib %PREFIX%\libs\
+if errorlevel 1 exit 1
+del %PREFIX%\libs\libpython*.a
+
+xcopy /s /y %SRC_DIR%\Lib %PREFIX%\Lib\
+if errorlevel 1 exit 1
+
+REM ========== bytecode compile standard library
+
+rd /s /q %STDLIB_DIR%\lib2to3\tests\
+if errorlevel 1 exit 1
+
+%PYTHON% -Wi %STDLIB_DIR%\compileall.py -f -q -x "bad_coding|badsyntax|py2_" %STDLIB_DIR%
+if errorlevel 1 exit 1
+
+REM ========== add scripts
+
+mkdir %SCRIPTS%
+if errorlevel 1 exit 1
+
+for %%x in (idle pydoc) do (
+    copy /Y %SRC_DIR%\Tools\scripts\%%x3 %SCRIPTS%\%%x
+    if errorlevel 1 exit 1
+)
+
+copy /Y %SRC_DIR%\Tools\scripts\2to3 %SCRIPTS%
+if errorlevel 1 exit 1

--- a/python-3.5/bld.bat
+++ b/python-3.5/bld.bat
@@ -15,6 +15,7 @@ for %%x in (DLLs Doc libs tcl Tools) do (
     xcopy /s /y %MSI_DIR%\%%x %PREFIX%\%%x\
     if errorlevel 1 exit 1
 )
+
 copy %MSI_DIR%\LICENSE.txt %PREFIX%\LICENSE_PYTHON.txt
 if errorlevel 1 exit 1
 
@@ -22,6 +23,7 @@ REM ========== add stuff from our own build
 
 xcopy /s /y %SRC_DIR%\Include %PREFIX%\include\
 if errorlevel 1 exit 1
+
 copy /Y %SRC_DIR%\PC\pyconfig.h %PREFIX%\include\
 if errorlevel 1 exit 1
 
@@ -31,6 +33,7 @@ for %%x in (python35.dll python.exe pythonw.exe) do (
 )
 copy /Y %SRC_DIR%\PCbuild\python35.lib %PREFIX%\libs\
 if errorlevel 1 exit 1
+
 del %PREFIX%\libs\libpython*.a
 
 xcopy /s /y %SRC_DIR%\Lib %PREFIX%\Lib\

--- a/python-3.5/bld.bat
+++ b/python-3.5/bld.bat
@@ -42,8 +42,12 @@ xcopy /s /y %SRC_DIR%\Lib %PREFIX%\Lib\
 if errorlevel 1 exit 1
 
 REM ========== add MS VC runtime dlls
+REM ========== REQUIRES Win 10 SDK be installed, or files otherwise copied to location below!
 
 xcopy /s /y "C:\Program Files (x86)\Windows Kits\10\Redist\ucrt\DLLs\%VC_PATH%\*" %PREFIX%\
+
+REM ========== This one comes from visual studio
+xcopy /s /y "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist\%VC_PATH%\Microsoft.VC140.CRT\*.dll" %PREFIX%\
 
 REM ========== bytecode compile standard library
 

--- a/python-3.5/bld.bat
+++ b/python-3.5/bld.bat
@@ -2,8 +2,10 @@ REM ========== actual compile step
 
 if "%ARCH%"=="64" (
    set PLATFORM=x64
+   set VC_PATH=x64
 ) else (
    set PLATFORM=Win32
+   set VC_PATH=x86
 )
 
 msbuild PCbuild\pcbuild.sln /t:python;pythoncore;pythonw;python3dll /p:Configuration=Release /p:Platform=%PLATFORM% /m /p:OutDir=%SRC_DIR%\PCBuild\
@@ -38,6 +40,10 @@ del %PREFIX%\libs\libpython*.a
 
 xcopy /s /y %SRC_DIR%\Lib %PREFIX%\Lib\
 if errorlevel 1 exit 1
+
+REM ========== add MS VC runtime dlls
+
+xcopy /s /y "C:\Program Files (x86)\Windows Kits\10\Redist\ucrt\DLLs\%VC_PATH%\*" %PREFIX%\
 
 REM ========== bytecode compile standard library
 

--- a/python-3.5/bld.bat
+++ b/python-3.5/bld.bat
@@ -46,7 +46,7 @@ if errorlevel 1 exit 1
 
 REM ========== add scripts
 
-mkdir %SCRIPTS%
+IF NOT exist %SCRIPTS% (mkdir %SCRIPTS%)
 if errorlevel 1 exit 1
 
 for %%x in (idle pydoc) do (

--- a/python-3.5/bld.bat
+++ b/python-3.5/bld.bat
@@ -10,7 +10,7 @@ msbuild PCbuild\pcbuild.sln /t:python;pythoncore;pythonw;python3dll /p:Configura
 
 REM ========== add stuff from official python.org installer
 
-set MSI_DIR=\Pythons\3.5.0rc2-%ARCH%
+set MSI_DIR=\Pythons\3.5.0-%ARCH%
 for %%x in (DLLs Doc libs tcl Tools Scripts) do (
     xcopy /s /y %MSI_DIR%\%%x %PREFIX%\%%x\
     if errorlevel 1 exit 1

--- a/python-3.5/bld.bat
+++ b/python-3.5/bld.bat
@@ -11,7 +11,7 @@ msbuild PCbuild\pcbuild.sln /t:python;pythoncore;pythonw;python3dll /p:Configura
 REM ========== add stuff from official python.org installer
 
 set MSI_DIR=\Pythons\3.5.0-%ARCH%
-for %%x in (DLLs Doc libs tcl Tools Scripts) do (
+for %%x in (DLLs Doc libs tcl Tools) do (
     xcopy /s /y %MSI_DIR%\%%x %PREFIX%\%%x\
     if errorlevel 1 exit 1
 )

--- a/python-3.5/build.sh
+++ b/python-3.5/build.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+REPLACE=replace
+
+if [ `uname` == Darwin ]; then
+    export CFLAGS="-I$PREFIX/include $CFLAGS"
+    export LDFLAGS="-L$PREFIX/lib -headerpad_max_install_names $LDFLAGS"
+    $REPLACE "@OSX_ARCH@" "$ARCH" Lib/distutils/unixccompiler.py
+fi
+
+PYTHON_BAK=$PYTHON
+unset PYTHON
+
+if [ `uname` == Darwin ]; then
+    ./configure --enable-shared --enable-ipv6 --with-ensurepip=no \
+        --prefix=$PREFIX
+fi
+if [ `uname` == Linux ]; then
+    ./configure --enable-shared --enable-ipv6 --with-ensurepip=no \
+        --prefix=$PREFIX \
+        --with-tcltk-includes="-I$PREFIX/include" \
+        --with-tcltk-libs="-L$PREFIX/lib -ltcl8.5 -ltk8.5" \
+        CPPFLAGS="-I$PREFIX/include" \
+        LDFLAGS="-L$PREFIX/lib -Wl,-rpath=$PREFIX/lib,--no-as-needed"
+fi
+
+make
+make install
+ln -s $PREFIX/bin/python3.5 $PREFIX/bin/python
+ln -s $PREFIX/bin/pydoc3.5 $PREFIX/bin/pydoc
+export PYTHON=$PYTHON_BAK
+
+if [ `uname` == Darwin ]; then
+    DYNLOAD_DIR=$STDLIB_DIR/lib-dynload
+    pushd Modules
+    rm -rf build
+    cp $RECIPE_DIR/setup_misc.py .
+    $PYTHON setup_misc.py build
+    cp $SRC_DIR/Modules/build/lib.macosx-*/_hashlib.so \
+       $SRC_DIR/Modules/build/lib.macosx-*/_ssl.so \
+       $SRC_DIR/Modules/build/lib.macosx-*/_sqlite3.so \
+       $SRC_DIR/Modules/build/lib.macosx-*/_tkinter.so \
+           $DYNLOAD_DIR
+    popd
+    pushd $DYNLOAD_DIR
+    mv readline_failed.so readline.so
+    popd
+fi
+
+if [ $CC != "gcc" ]; then
+    $REPLACE $CC gcc $STDLIB_DIR/_sysconfigdata.py \
+        $STDLIB_DIR/config-3.5m/Makefile
+    $REPLACE $CXX g++ $STDLIB_DIR/_sysconfigdata.py \
+        $STDLIB_DIR/config-3.5m/Makefile
+fi
+
+$REPLACE '-Werror=declaration-after-statement' '' \
+    $PREFIX/lib/python3.5/_sysconfigdata.py \
+    $PREFIX/lib/python3.5/config-3.5m/Makefile
+

--- a/python-3.5/meta.yaml
+++ b/python-3.5/meta.yaml
@@ -1,0 +1,47 @@
+package:
+  name: python
+  version: 3.5.0rc2
+
+source:
+  fn: Python-3.5.0rc2.tgz
+  url: https://www.python.org/ftp/python/3.5.0/Python-3.5.0rc2.tgz
+  md5: bfd6938e8072b768a277125837eb7aed
+  patches:
+    - version.patch
+    - osx-dist.patch        [osx]
+    - win-find_exe.patch    [win]
+
+build:
+  no_link: 
+    - bin/python
+  number: 1       [linux]
+
+requirements:
+  build:
+    - bzip2       [unix]
+    - zlib        [unix]
+    - sqlite      [unix]
+    - readline    [unix]
+    - tk          [unix]
+    - openssl     [unix]
+    - xz          [unix]
+  run:
+    - zlib        [unix]
+    - sqlite      [unix]
+    - readline    [unix]
+    - tk          [unix]
+    - openssl     [unix]
+    - xz          [unix]
+
+test:
+  commands:
+    - python -V               [unix]
+    - python3 -V              [unix]
+    - 2to3 -h
+    - pydoc -h
+    - python3-config --help   [unix]
+
+about:
+  home: http://www.python.org/
+  license: PSF
+  summary: general purpose programming language

--- a/python-3.5/meta.yaml
+++ b/python-3.5/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: python
-  version: 3.5.0rc2
+  version: 3.5.0rc4
 
 source:
-  fn: Python-3.5.0rc2.tgz
-  url: https://www.python.org/ftp/python/3.5.0/Python-3.5.0rc2.tgz
-  md5: bfd6938e8072b768a277125837eb7aed
+  fn: Python-3.5.0rc4.tgz
+  url: https://www.python.org/ftp/python/3.5.0/Python-3.5.0rc4.tgz
+  md5: 3ebd84ed4b63558c0d4d3465b32801f8
   patches:
     - version.patch
     - osx-dist.patch        [osx]

--- a/python-3.5/meta.yaml
+++ b/python-3.5/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: python
-  version: 3.5.0rc4
+  version: 3.5.0
 
 source:
-  fn: Python-3.5.0rc4.tgz
-  url: https://www.python.org/ftp/python/3.5.0/Python-3.5.0rc4.tgz
-  md5: 3ebd84ed4b63558c0d4d3465b32801f8
+  fn: Python-3.5.0.tgz
+  url: https://www.python.org/ftp/python/3.5.0/Python-3.5.0.tgz
+  md5: a56c0c0b45d75a0ec9c6dee933c41c36
   patches:
     - version.patch
     - osx-dist.patch        [osx]

--- a/python-3.5/osx-dist.patch
+++ b/python-3.5/osx-dist.patch
@@ -1,0 +1,12 @@
+diff --git Lib/distutils/unixccompiler.py Lib/distutils/unixccompiler.py
+index 094a2f0..4252605 100644
+--- Lib/distutils/unixccompiler.py
++++ Lib/distutils/unixccompiler.py
+@@ -189,6 +189,7 @@ class UnixCCompiler(CCompiler):
+                     linker[i] = self.compiler_cxx[i]
+ 
+                 if sys.platform == 'darwin':
++                    ld_args = ['-m@OSX_ARCH@'] + ld_args
+                     linker = _osx_support.compiler_fixup(linker, ld_args)
+ 
+                 self.spawn(linker + ld_args)

--- a/python-3.5/run_test.py
+++ b/python-3.5/run_test.py
@@ -1,0 +1,106 @@
+import platform
+import sys
+import subprocess
+
+armv6l = bool(platform.machine() == 'armv6l')
+armv7l = bool(platform.machine() == 'armv7l')
+ppc64le = bool(platform.machine() == 'ppc64le')
+if sys.platform == 'darwin':
+    osx105 = b'10.5.' in subprocess.check_output('sw_vers')
+else:
+    osx105 = False
+
+print('sys.version:', sys.version)
+print('sys.platform:', sys.platform)
+print('tuple.__itemsize__:', tuple.__itemsize__)
+if sys.platform == 'win32':
+    assert 'MSC v.1900' in sys.version
+print('sys.maxunicode:', sys.maxunicode)
+print('platform.architecture:', platform.architecture())
+print('platform.python_version:', platform.python_version())
+
+import _bisect
+import _codecs_cn
+import _codecs_hk
+import _codecs_iso2022
+import _codecs_jp
+import _codecs_kr
+import _codecs_tw
+import _collections
+import _csv
+import _ctypes
+import _ctypes_test
+import _decimal
+import _elementtree
+import _functools
+import _hashlib
+import _heapq
+import _io
+import _json
+import _locale
+import _lsprof
+import _lzma
+import _multibytecodec
+import _multiprocessing
+import _random
+import _socket
+import _sqlite3
+import _ssl
+import _struct
+import _testcapi
+import array
+import audioop
+import binascii
+import bz2
+import cmath
+import datetime
+import itertools
+import lzma
+import math
+import mmap
+import operator
+import parser
+import pyexpat
+import select
+import time
+import unicodedata
+import zlib
+from os import urandom
+
+t = 100 * b'Foo '
+assert lzma.decompress(lzma.compress(t)) == t
+
+if sys.platform != 'win32':
+    if not (ppc64le or armv7l):
+        import _curses
+        import _curses_panel
+    import crypt
+    import fcntl
+    import grp
+    import nis
+    import readline
+    import resource
+    import syslog
+    import termios
+
+    from distutils import sysconfig
+    for var_name in 'LDSHARED', 'CC':
+        value = sysconfig.get_config_var(var_name)
+        assert value.split()[0] == 'gcc', value
+    for var_name in 'LDCXXSHARED', 'CXX':
+        value = sysconfig.get_config_var(var_name)
+        assert value.split()[0] == 'g++', value
+
+if not (armv6l or armv7l or ppc64le or osx105):
+    import tkinter
+    import turtle
+    import _tkinter
+    print('TK_VERSION: %s' % _tkinter.TK_VERSION)
+    print('TCL_VERSION: %s' % _tkinter.TCL_VERSION)
+    TCLTK_VER = '8.6' if sys.platform == 'win32' else '8.5'
+    assert _tkinter.TK_VERSION == _tkinter.TCL_VERSION == TCLTK_VER
+
+import ssl
+print('OPENSSL_VERSION:', ssl.OPENSSL_VERSION)
+if sys.platform != 'win32':
+    assert '1.0.1k' in ssl.OPENSSL_VERSION

--- a/python-3.5/setup_misc.py
+++ b/python-3.5/setup_misc.py
@@ -1,0 +1,44 @@
+# used to build the tk interface on 64-bit darwin
+import sys
+from distutils.core import setup, Extension
+
+
+setup(
+    ext_modules = [
+        Extension(
+            '_sqlite3', ['_sqlite/cache.c',
+                         '_sqlite/connection.c',
+                         '_sqlite/cursor.c',
+                         '_sqlite/microprotocols.c',
+                         '_sqlite/module.c',
+                         '_sqlite/prepare_protocol.c',
+                         '_sqlite/row.c',
+                         '_sqlite/statement.c',
+                         '_sqlite/util.c',],
+            define_macros=[('MODULE_NAME', '"sqlite3"')],
+            libraries = ['sqlite3'],
+            include_dirs = [sys.prefix + '/include'],
+            library_dirs = [sys.prefix + '/lib'],
+        ),
+        Extension(
+            '_ssl', ['_ssl.c'],
+            libraries = ['ssl', 'crypto'],
+            depends = ['socketmodule.h'],
+            include_dirs = [sys.prefix + '/include'],
+            library_dirs = [sys.prefix + '/lib'],
+        ),
+        Extension(
+            '_hashlib', ['_hashopenssl.c'],
+            libraries = ['ssl', 'crypto'],
+            include_dirs = [sys.prefix + '/include'],
+            library_dirs = [sys.prefix + '/lib'],
+        ),
+        Extension(
+            '_tkinter', ['_tkinter.c', 'tkappinit.c'],
+            define_macros=[('WITH_APPINIT', 1)],
+            libraries=['tcl8.5', 'tk8.5'],
+            include_dirs = [sys.prefix + '/include', '/usr/X11R6/include'],
+            library_dirs = [sys.prefix + '/lib'],
+        ),
+    ],
+)

--- a/python-3.5/version.patch
+++ b/python-3.5/version.patch
@@ -1,0 +1,97 @@
+diff --git Include/pylifecycle.h Include/pylifecycle.h
+index ccdebe2..9b181f2 100644
+--- Include/pylifecycle.h
++++ Include/pylifecycle.h
+@@ -63,6 +63,7 @@ int _Py_CheckPython3();
+ #endif
+ 
+ /* In their own files */
++PyAPI_FUNC(const char *) Anaconda_GetVersion(void);
+ PyAPI_FUNC(const char *) Py_GetVersion(void);
+ PyAPI_FUNC(const char *) Py_GetPlatform(void);
+ PyAPI_FUNC(const char *) Py_GetCopyright(void);
+diff --git Lib/platform.py Lib/platform.py
+index 9096696..1cccdd4 100644
+--- Lib/platform.py
++++ Lib/platform.py
+@@ -1194,6 +1194,7 @@ def processor():
+ 
+ _sys_version_parser = re.compile(
+     r'([\w.+]+)\s*'
++    '\|[^|]*\|\s*' # version extra
+     '\(#?([^,]+),\s*([\w ]+),\s*([\w :]+)\)\s*'
+     '\[([^\]]+)\]?', re.ASCII)
+ 
+diff --git Modules/main.c Modules/main.c
+index 2a9ea28..ae829de 100644
+--- Modules/main.c
++++ Modules/main.c
+@@ -502,7 +502,8 @@ Py_Main(int argc, wchar_t **argv)
+         return usage(0, argv[0]);
+ 
+     if (version) {
+-        printf("Python %s\n", PY_VERSION);
++        Py_SetProgramName(argv[0]);
++        fprintf(stderr, "Python %s :: %s\n", PY_VERSION, Anaconda_GetVersion());
+         return 0;
+     }
+ 
+diff --git Python/getversion.c Python/getversion.c
+index 7bd6efd..c0a1e0f 100644
+--- Python/getversion.c
++++ Python/getversion.c
+@@ -2,14 +2,51 @@
+ /* Return the full version string. */
+ 
+ #include "Python.h"
+-
++#include "osdefs.h"
+ #include "patchlevel.h"
+ 
++#ifdef MS_WIN32
++#define STDLIB_DIR  L"\\Lib\\"
++#else
++#define STDLIB_DIR  L"/lib/python3.5/"
++#endif
++
++const char *
++Anaconda_GetVersion(void)
++{
++    static char res[128];
++    FILE *f;
++    wchar_t path[MAXPATHLEN+1];
++    int c, i;
++
++    wcscpy(path, Py_GetPrefix());
++    wcscat(path, STDLIB_DIR L"version.txt");
++
++    f = _Py_wfopen(path, L"rb");
++    if (f == NULL) {
++      strcpy(res, "Continuum Analytics, Inc.");
++    }
++    else {
++      i = 0;
++      while (i + 1 < sizeof(res)) {
++        c = fgetc(f);
++        if (c == EOF || c == '\n' || c == '\r')
++          break;
++        res[i++] = c;
++       }
++       fclose(f);
++       res[i] = '\0';
++    }
++    return res;
++}
++
++#undef STDLIB_DIR
++
+ const char *
+ Py_GetVersion(void)
+ {
+ 	static char version[250];
+-	PyOS_snprintf(version, sizeof(version), "%.80s (%.80s) %.80s",
+-		      PY_VERSION, Py_GetBuildInfo(), Py_GetCompiler());
++	PyOS_snprintf(version, sizeof(version), "%.80s |%s| (%.80s) %.80s",
++                PY_VERSION, Anaconda_GetVersion(), Py_GetBuildInfo(), Py_GetCompiler());
+ 	return version;
+ }

--- a/python-3.5/win-find_exe.patch
+++ b/python-3.5/win-find_exe.patch
@@ -1,0 +1,35 @@
+diff --git Lib/distutils/spawn.py Lib/distutils/spawn.py
+index 5dd415a..ce85901 100644
+--- Lib/distutils/spawn.py
++++ Lib/distutils/spawn.py
+@@ -176,17 +176,16 @@ def find_executable(executable, path=None):
+         path = os.environ['PATH']
+ 
+     paths = path.split(os.pathsep)
+-    base, ext = os.path.splitext(executable)
+-
+-    if (sys.platform == 'win32') and (ext != '.exe'):
+-        executable = executable + '.exe'
+-
+-    if not os.path.isfile(executable):
+-        for p in paths:
+-            f = os.path.join(p, executable)
+-            if os.path.isfile(f):
+-                # the file exists, we have a shot at spawn working
+-                return f
+-        return None
+-    else:
+-        return executable
++
++    for ext in '.exe', '.bat', '':
++        newexe = executable + ext
++
++        if os.path.isfile(newexe):
++            return newexe
++        else:
++            for p in paths:
++                f = os.path.join(p, newexe)
++                if os.path.isfile(f):
++                    # the file exists, we have a shot at spawn working
++                    return f
++    return None


### PR DESCRIPTION
This is tested on Windows, but may need further work on Mac and Linux.

In general, I have needed to build this with commands like:

conda build --python="3.5" .

(which, with recent conda-build fixes will employ VS 2015 compiler).  If you do not do this, conda build will try to use either VS2008 (anaconda/miniconda) or VS2010 (anaconda3/miniconda3)

To build 32-bit rather than native format, use Conda's build environment variable (CONDA_FORCE_32BIT)