### PR TITLE
patches to allow geos 3.4.2 to build with VS2015

### DIFF
--- a/geos/bufferopp.patch
+++ b/geos/bufferopp.patch
@@ -1,0 +1,28 @@
+--- src\operation\buffer\BufferOp.cpp.orig	2015-11-13 12:18:57.302468000 +1000
++++ src\operation\buffer\BufferOp.cpp	2015-11-13 12:19:29.081764900 +1000
+@@ -17,7 +17,11 @@
+  * Last port: operation/buffer/BufferOp.java r378 (JTS-1.12)
+  *
+  **********************************************************************/
+-
++#if _MSC_VER >= 1900
++#include <algorithm>
++#define max(x, y) std::max(x, y)
++#define min(x, y) std::min(x, y)
++#endif
+ #include <algorithm>
+ #include <cmath>
+ 
+@@ -85,9 +89,9 @@
+ 	int maxPrecisionDigits)
+ {
+   const Envelope *env=g->getEnvelopeInternal();
+-  double envMax = std::max(
+-    std::max(fabs(env->getMaxX()), fabs(env->getMinX())),
+-    std::max(fabs(env->getMaxY()), fabs(env->getMinY()))
++  double envMax = max(
++    max(fabs(env->getMaxX()), fabs(env->getMinX())),
++    max(fabs(env->getMaxY()), fabs(env->getMinY()))
+   );
+ 
+   double expandByDistance = distance > 0.0 ? distance : 0.0;

--- a/geos/lineintersector.patch
+++ b/geos/lineintersector.patch
@@ -1,0 +1,14 @@
+--- src\algorithm\LineIntersector.cpp.orig	2013-08-26 01:10:29.000000000 +1000
++++ src\algorithm\LineIntersector.cpp	2015-11-13 11:49:38.744850900 +1000
+@@ -17,6 +17,11 @@
+  *
+  **********************************************************************/
+ 
++#if _MSC_VER >= 1900
++#include <algorithm>
++#define max(x, y) std::max(x, y)
++#define min(x, y) std::min(x, y)
++#endif
+ #include <geos/algorithm/LineIntersector.h>
+ #include <geos/algorithm/CGAlgorithms.h>
+ #include <geos/algorithm/HCoordinate.h>

--- a/geos/meta.yaml
+++ b/geos/meta.yaml
@@ -5,7 +5,14 @@ package:
 source:
   fn: geos-3.4.2.tar.bz2
   url: http://download.osgeo.org/geos/geos-3.4.2.tar.bz2
-
+  md5: fc5df2d926eb7e67f988a43a92683bae
+  patches:
+    - lineintersector.patch [win]
+    - wktwriter.patch [win]
+    - bufferopp.patch [win]
+    - offsetcurvebuilder.patch [win]
+    - offsetcurvesetbuilder.patch [win]
+    
 
 about:
   home: http://trac.osgeo.org/geos/

--- a/geos/offsetcurvebuilder.patch
+++ b/geos/offsetcurvebuilder.patch
@@ -1,0 +1,14 @@
+--- src\operation\buffer\OffsetCurveBuilder.cpp.orig	2015-11-13 12:37:59.568957600 +1000
++++ src\operation\buffer\OffsetCurveBuilder.cpp	2015-11-13 12:18:31.159889900 +1000
+@@ -17,6 +17,11 @@
+  * Last port: operation/buffer/OffsetCurveBuilder.java r378 (JTS-1.12)
+  *
+  **********************************************************************/
++#if _MSC_VER >= 1900
++#include <algorithm>
++#define max(x, y) std::max(x, y)
++#define min(x, y) std::min(x, y)
++#endif
+ #include <cassert>
+ #include <cmath>
+ #include <vector>

--- a/geos/offsetcurvesetbuilder.patch
+++ b/geos/offsetcurvesetbuilder.patch
@@ -1,0 +1,27 @@
+--- src\operation\buffer\OffsetCurvesetBuilder.cpp.orig	2013-08-26 01:10:29.000000000 +1000
++++ src\operation\buffer\OffsetCurvesetBuilder.cpp	2015-11-13 12:21:59.687233700 +1000
+@@ -17,7 +17,12 @@
+  * Last port: operation/buffer/OffsetCurveSetBuilder.java r378 (JTS-1.12)
+  *
+  **********************************************************************/
+-
++#if _MSC_VER >= 1900
++#include <algorithm>
++#define max(x, y) std::max(x, y)
++#define min(x, y) std::min(x, y)
++#define abs(x) std::abs(x)
++#endif
+ #include <geos/algorithm/CGAlgorithms.h>
+ #include <geos/algorithm/MinimumDiameter.h>
+ #include <geos/util/UnsupportedOperationException.h>
+@@ -333,8 +338,8 @@
+ 		return isTriangleErodedCompletely(ringCoord, bufferDistance);
+ 
+   const Envelope* env = ring->getEnvelopeInternal();
+-  double envMinDimension = std::min(env->getHeight(), env->getWidth());
+-  if (bufferDistance < 0.0 && 2 * std::abs(bufferDistance) > envMinDimension)
++  double envMinDimension = min(env->getHeight(), env->getWidth());
++  if (bufferDistance < 0.0 && 2 * abs(bufferDistance) > envMinDimension)
+       return true;
+ 
+ 	/**

--- a/geos/wktwriter.patch
+++ b/geos/wktwriter.patch
@@ -1,0 +1,14 @@
+--- src\io\WKTWriter.cpp.orig	2013-08-26 01:10:30.000000000 +1000
++++ src\io\WKTWriter.cpp	2015-11-13 12:15:42.758522700 +1000
+@@ -18,6 +18,11 @@
+  *
+  **********************************************************************/
+ 
++#if _MSC_VER >= 1900
++#include <algorithm>
++#define max(x, y) std::max(x, y)
++#define min(x, y) std::min(x, y)
++#endif
+ #include <geos/io/WKTWriter.h>
+ #include <geos/io/Writer.h>
+ #include <geos/io/CLocalizer.h>


### PR DESCRIPTION
Seems a bit messy but this was the least invasive way I could think of getting geos 3.4.2 building with VS2015.

I think this is safer than using geos 3.5.0 which will need a bit of testing.