### PR TITLE
Allow libgdal to be built with VS2015

### DIFF
--- a/libgdal/meta.yaml
+++ b/libgdal/meta.yaml
@@ -6,7 +6,9 @@ source:
   url: http://download.osgeo.org/gdal/2.0.0/gdal-2.0.0.tar.gz
   fn: libgdal-2.0.0.tar.gz
   md5: 2c5f8f12ed416febd2cbd7b63c48eb17
-
+  patches:
+    - nmake.patch [win]
+    
 build:
   number: 1
 

--- a/libgdal/meta.yaml
+++ b/libgdal/meta.yaml
@@ -10,7 +10,7 @@ source:
     - nmake.patch [win]
     
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:

--- a/libgdal/nmake.patch
+++ b/libgdal/nmake.patch
@@ -1,10 +1,12 @@
 --- nmake.opt.orig	2015-06-15 05:06:33.000000000 +1000
-+++ nmake.opt	2015-11-19 16:31:36.978091100 +1000
-@@ -641,7 +641,7 @@
++++ nmake.opt	2015-11-19 16:44:13.167544200 +1000
+@@ -641,7 +641,10 @@
  !ENDIF
  
  !IFDEF ODBC_SUPPORTED
--ODBCLIB = odbc32.lib odbccp32.lib user32.lib
++!IF "$(CONDA_PY)" != "35"
+ ODBCLIB = odbc32.lib odbccp32.lib user32.lib
++!ELSE
 +ODBCLIB = legacy_stdio_definitions.lib odbc32.lib odbccp32.lib user32.lib
  !ENDIF
  

--- a/libgdal/nmake.patch
+++ b/libgdal/nmake.patch
@@ -1,0 +1,11 @@
+--- nmake.opt.orig	2015-06-15 05:06:33.000000000 +1000
++++ nmake.opt	2015-11-19 16:31:36.978091100 +1000
+@@ -641,7 +641,7 @@
+ !ENDIF
+ 
+ !IFDEF ODBC_SUPPORTED
+-ODBCLIB = odbc32.lib odbccp32.lib user32.lib
++ODBCLIB = legacy_stdio_definitions.lib odbc32.lib odbccp32.lib user32.lib
+ !ENDIF
+ 
+ !IF DEFINED(MRSID_DIR) || DEFINED(MRSID_RASTER_DIR) || DEFINED(MRSID_LIDAR_DIR)

--- a/libgdal/scripts/activate.bat
+++ b/libgdal/scripts/activate.bat
@@ -1,4 +1,4 @@
 if not defined GDAL_DATA (
-  set GDAL_DATA="%~dp0\..\..\..\Library\share\gdal"
+  set "GDAL_DATA=%~dp0\..\..\..\Library\share\gdal"
   set _CONDA_SET_GDAL_DATA=1
 )


### PR DESCRIPTION
Build problem seems related to this:

https://connect.microsoft.com/VisualStudio/feedback/details/1039102
https://github.com/mapbox/windows-builds/issues/53

Solution is to add legacy_stdio_definitions.lib to libs for Python35 (VS2015) builds.
