### PR TITLE
fix proj4 install on Windows

### DIFF
--- a/proj4/meta.yaml
+++ b/proj4/meta.yaml
@@ -1,17 +1,21 @@
 package:
   name: proj4
-  version: 4.9.1
+  version: 4.9.2
 
 source:
-  fn: proj-4.9.1.tar.gz
-  url: http://download.osgeo.org/proj/proj-4.9.1.tar.gz
+  git_url: https://github.com/OSGeo/proj.4
+  git_rev: 4.9.2
 
 build:
   number: 0
   features:
-    - vc9   [win and py27]
-    - vc10  [win and py34]
-    - vc15  [win and py35]
+    - vc9     [win and py27]
+    - vc10    [win and py34]
+    - vc14    [win and py35]
+
+requirements:
+  build:
+    - python [win]
 
 about:
   home: http://trac.osgeo.org/proj/


### PR DESCRIPTION
The features were not correctly mapping to Python version numbers.