### PR TITLE
BUG: numexpr must link against mkl_rt

### DIFF
--- a/numexpr/site-mkl-linux-32.cfg
+++ b/numexpr/site-mkl-linux-32.cfg
@@ -1,4 +1,4 @@
 [mkl]
 library_dirs = @PREFIX@/lib
 include_dirs = @PREFIX@/include
-mkl_libs = mkl_intel, mkl_intel_thread, mkl_core, iomp5
+mkl_libs = mkl_rt

--- a/numexpr/site-mkl-linux-64.cfg
+++ b/numexpr/site-mkl-linux-64.cfg
@@ -1,4 +1,4 @@
 [mkl]
 library_dirs = @PREFIX@/lib
 include_dirs = @PREFIX@/include
-mkl_libs = mkl_intel_lp64, mkl_intel_thread, mkl_core, iomp5
+mkl_libs = mkl_rt

--- a/numexpr/site-mkl-osx-64.cfg
+++ b/numexpr/site-mkl-osx-64.cfg
@@ -1,4 +1,4 @@
 [mkl]
 library_dirs = @PREFIX@/lib
 include_dirs = @PREFIX@/include
-mkl_libs = mkl_core, mkl_intel_lp64, mkl_intel_thread, mkl_mc, mkl_mc3, mkl_vml_mc, mkl_vml_mc2, mkl_vml_mc3, mkl_rt, iomp5
+mkl_libs = mkl_rt

--- a/numexpr/site-mkl-win-32.cfg
+++ b/numexpr/site-mkl-win-32.cfg
@@ -1,4 +1,4 @@
 [mkl]
 include_dirs = @PREFIX@\Library\include
-library_dirs = @PREFIX@\Library\lib
-mkl_libs = mkl_sequential_dll, mkl_core_dll, mkl_intel_c_dll, mkl_intel_thread_dll
+library_dirs = @PREFIX@\Library\bin
+mkl_libs = mkl_rt

--- a/numexpr/site-mkl-win-64.cfg
+++ b/numexpr/site-mkl-win-64.cfg
@@ -1,4 +1,4 @@
 [mkl]
 include_dirs = @PREFIX@\Library\include
-library_dirs = @PREFIX@\Library\lib
-mkl_libs = mkl_sequential_dll, mkl_core_dll, mkl_intel_lp64_dll, mkl_intel_thread_dll
+library_dirs = @PREFIX@\Library\bin
+mkl_libs = mkl_rt


### PR DESCRIPTION
This fixes issues like

https://github.com/conda/conda/issues/2031

Additionally, on Windows, `library_dirs` should be `@PREFIX@\Library\bin`, rather than `@PREFIX@\Library\lib`, since the MKL library is being installed in the former.