### PR TITLE
Add pyqt to dependencies for glueviz

### DIFF
--- a/glueviz/meta.yaml
+++ b/glueviz/meta.yaml
@@ -34,6 +34,7 @@ requirements:
     - astropy >=1.0
     - matplotlib >=1.4
     - qtpy >=1.1
+    - pyqt
 
     # The following is needed to make sure that the package works as a GUI
     # application (glue needs to be run with python.app, not python)


### PR DESCRIPTION
PyQt is a required dependency of glue - it's not included in ``install_requires`` since PyQt can't be pip installed, but it is a required dependency.