### PR TITLE
keyring: add/patch platform specific requirements

### DIFF
--- a/keyring/meta.yaml
+++ b/keyring/meta.yaml
@@ -7,6 +7,9 @@ source:
   url: https://pypi.python.org/packages/7e/84/65816c2936cf7191bcb5b3e3dc4fb87def6f8a38be25b3a78131bbb08594/keyring-9.3.1.tar.gz
   md5: 934aad9f3cdcc860029a0122fb5f67bb
 
+  patches:
+    - platform-deps-fix.patch
+
 build:
   entry_points:
     - keyring = keyring.cli:main
@@ -15,13 +18,19 @@ requirements:
   build:
     - python
     - setuptools
-    - setuptools_scm
+    - setuptools_scm >=1.9
+    - pywin32        # [win]
   run:
     - python
+    - setuptools
+    - pywin32        # [win]
+    # - secretstorage  # [linux]
 
 test:
   commands:
     - keyring -h
+    - python -c "import pkg_resources as pr; pr.require('keyring')"
+
   imports:
     - keyring
 

--- a/keyring/platform-deps-fix.patch
+++ b/keyring/platform-deps-fix.patch
@@ -1,0 +1,16 @@
+diff --git a/setup.py b/setup.py
+index 58bdc17..b08b404 100644
+--- a/setup.py
++++ b/setup.py
+@@ -37,9 +37,8 @@ setup_params = dict(
+     ],
+     extras_require={
+         'test': test_requirements,
+-        ':sys_platform=="win32"': ['pywin32-ctypes'],
++        ':sys_platform=="win32"': ['pywin32'],
+         ':sys_platform=="linux2" or sys_platform=="linux"': [
+-            "secretstorage",
+         ],
+     },
+     setup_requires=[
+


### PR DESCRIPTION
Add pywin32 as a run requirement on windows

Patch setup.py to:

* 1) change pywin32-ctypes -> pywin32 (same patch is already used in
  conda-forge/keychain-feedstock)

* 2) remove secretstorage from dependencies on linux. secretstorage
  itself has dependency on dbus-python which is not available on
  anaconda/miniconda

