### PR TITLE
Build openmpi with conda-build.

### DIFF
--- a/openmpi/meta.yaml
+++ b/openmpi/meta.yaml
@@ -1,6 +1,3 @@
-# This is legacy recipe, which has not been tested using conda-build.
-# See: https://github.com/ContinuumIO/anaconda-recipes/blob/master/LEGACY.md
-
 package:
   name: openmpi
   version: 1.6.3
@@ -10,6 +7,10 @@ source:
   url: http://www.open-mpi.org/software/ompi/v1.6/downloads/openmpi-1.6.3.tar.bz2
   md5: eedb73155a7a40b0b07718494298fb25
 
+build:
+  detect_binary_files_with_prefix : true
+  number : 1
+  
 about:
   home: http://www.open-mpi.org/
   license: 3-clause BSD


### PR DESCRIPTION
Solves https://github.com/conda/conda/issues/2277

It turns out the reason it was broken was because the recipe was legacy -- and did not support relocating binary files -- a feature required to properly relocate openmpi.

The script built successfully with conda-build on my local mac. 