### PR TITLE
More ruamel fixes

### DIFF
--- a/ruamel_yaml/__init__.py
+++ b/ruamel_yaml/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 from __future__ import print_function, absolute_import
 
-__version__ = "0.11.7"
+__version__ = "$VERSION"
 __name__ = "ruamel_yaml"
 __author__ = "Anthon van der Neut"
 __author_email__ ="a.van.der.neut@ruamel.eu"

--- a/ruamel_yaml/meta.yaml
+++ b/ruamel_yaml/meta.yaml
@@ -15,6 +15,7 @@ requirements:
   build:
     - posix               # [win]
     - python
+    - setuptools
     - cython
     - yaml
   run:

--- a/ruamel_yaml/meta.yaml
+++ b/ruamel_yaml/meta.yaml
@@ -13,6 +13,7 @@ source:
 
 requirements:
   build:
+    - posix               # [win]
     - python
     - cython
     - yaml

--- a/ruamel_yaml/prepare.bash
+++ b/ruamel_yaml/prepare.bash
@@ -4,7 +4,7 @@ env | sort
 RECIPE_DIR=${1-$RECIPE_DIR}
 SRC_DIR=${2-$SRC_DIR}
 
-VERSION=$(python $SRC_DIR/setup.py --version)
+VERSION=$(cd $SRC_DIR && python setup.py --version)
 echo "VERSION=$VERSION"
 
 patch -p1 < $RECIPE_DIR/ordereddict_test.patch

--- a/ruamel_yaml/prepare.bash
+++ b/ruamel_yaml/prepare.bash
@@ -25,4 +25,4 @@ touch $SRC_DIR/ruamel_yaml/ext/__init__.py
 
 cp $RECIPE_DIR/setup.py $SRC_DIR/
 cp $RECIPE_DIR/__init__.py $SRC_DIR/ruamel_yaml/
-sed -i -e 's/__version__.*/__version__ = "$VERSION"/' $SRC_DIR/ruamel_yaml/__init__.py
+sed -i -e "s/__version__.*/__version__ = "'"'"${VERSION}"'"'"/" $SRC_DIR/ruamel_yaml/__init__.py


### PR DESCRIPTION
Follow-up to PR ( https://github.com/ContinuumIO/anaconda-recipes/pull/57 ). Also pulls some fixes that were discovered by working on the conda-forge update in PR ( https://github.com/conda-forge/ruamel_yaml-feedstock/pull/3 ). Summary of changes below. More details in each of the commit messages.

* Re-add the `sed` version fix from PR ( https://github.com/ContinuumIO/anaconda-recipes/pull/57 ). (see this [comment]( https://github.com/ContinuumIO/anaconda-recipes/commit/2d541e6b2b3270e815df752b34be2ff281c31e8a#commitcomment-20397548 ))
* Switch to source directory before extracting version from `setup.py`. (required on Windows)
* Change `__init__.py` for version patching.
* Require `posix` on Windows for building.
* Require `setuptools` for `build`. (needed for getting version before `setup.py` is patched)

cc @kalefranz