### PR TITLE
Matplotlib: Add a test

### DIFF
--- a/matplotlib/meta.yaml
+++ b/matplotlib/meta.yaml
@@ -57,8 +57,11 @@ test:
   requires:
     - nose
     - mock
+    - setuptools
   imports:
     - matplotlib
+  commands:
+    - python -c "import pkg_resources; pkg_resources.require('matplotlib')"
 
 about:
   home: http://matplotlib.org/


### PR DESCRIPTION
This test makes sure all matplotlib dependencies are already installed
which would prevent https://github.com/ContinuumIO/anaconda-issues/issues/1379#issuecomment-275640870
from happening.