### PR TITLE
[opencv] update to jpeg 9

### DIFF
--- a/opencv-3/meta.yaml
+++ b/opencv-3/meta.yaml
@@ -14,7 +14,7 @@ source:
     - cap_mpjpeg_decoder.patch  [win]
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
@@ -30,7 +30,7 @@ requirements:
     - hdf5 1.8.17    [unix]
     - eigen 3.*
     - zlib 1.2.*
-    - jpeg 8*
+    - jpeg 9*
     - libtiff 4.0.*
     - libpng >=1.6.21,<1.7
 #    - msinttypes            [win and py<35]
@@ -40,7 +40,7 @@ requirements:
     - numpy x.x
     - hdf5 1.8.17    [unix]
     - zlib 1.2.*
-    - jpeg 8*
+    - jpeg 9*
     - libtiff 4.0.*
     - libpng >=1.6.21,<1.7
 


### PR DESCRIPTION
`jpeg 9` is used in `anaconda 4.3.0`. This patch allows to install `opencv 3` alongside `anaconda 4.3.0`.