### PR TITLE
Add recipe for glue-vispy-viewers

### DIFF
--- a/glue-vispy-viewers/bld.bat
+++ b/glue-vispy-viewers/bld.bat
@@ -1,4 +1,4 @@
-%PYTHON% setup.py install
+%PYTHON% setup.py install --single-version-externally-managed --record record.txt
 if errorlevel 1 exit 1
 
 del %SCRIPTS%\easy_install*

--- a/glue-vispy-viewers/bld.bat
+++ b/glue-vispy-viewers/bld.bat
@@ -1,0 +1,9 @@
+%PYTHON% setup.py install
+if errorlevel 1 exit 1
+
+del %SCRIPTS%\easy_install*
+
+if %PY3K%==1 (
+    rd /s /q %SP_DIR%\__pycache__
+    rd /s /q %SP_DIR%\PyQt5
+)

--- a/glue-vispy-viewers/build.sh
+++ b/glue-vispy-viewers/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+rm -rf $SP_DIR/PyQt5

--- a/glue-vispy-viewers/build.sh
+++ b/glue-vispy-viewers/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-$PYTHON setup.py install
+$PYTHON setup.py install --single-version-externally-managed --record record.txt
 
 rm -rf $SP_DIR/PyQt5

--- a/glue-vispy-viewers/meta.yaml
+++ b/glue-vispy-viewers/meta.yaml
@@ -1,0 +1,33 @@
+package:
+  name: glue-vispy-viewers
+  version: 0.6
+
+source:
+  fn: glue-vispy-viewers-0.6.tar.gz
+  url: https://pypi.io/packages/source/g/glue-vispy-viewers/glue-vispy-viewers-0.6.tar.gz
+  md5: 07b0ec9fec510352edc617e95ee86469
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - numpy
+    - pyopengl
+    - glueviz >=0.9
+
+test:
+  imports:
+    - glue_vispy_viewers
+    - glue_vispy_viewers.scatter
+    - glue_vispy_viewers.volume
+
+about:
+  home: https://github.com/glue-viz/glue-vispy-viewers
+  license: 3-clause BSD License
+  license_family: BSD
+  license_file: LICENSE
+  summary: 3D viewers for glue
+  doc_url: http://www.glueviz.org/
+  dev_url: https://github.com/glue-viz/glue-vispy-viewers


### PR DESCRIPTION
This is a companion PR to https://github.com/ContinuumIO/anaconda-recipes/pull/83. The glueviz package now has a required dependency on glue-vispy-viewers, which is a component of glueviz that is distributed as a separate package. I discussed with @ilanschnell recently that some components of glue may become separate packages, and this is the case here.

This PR should be merged before https://github.com/ContinuumIO/anaconda-recipes/pull/83 since it otherwise https://github.com/ContinuumIO/anaconda-recipes/pull/83 will fail due to the missing glue-vispy-viewers dependency.