### PR TITLE
Add missing dask dependency for scikit-image

### DIFF
--- a/scikit-image/meta.yaml
+++ b/scikit-image/meta.yaml
@@ -32,6 +32,7 @@ requirements:
     - matplotlib >=1.3.1
     - networkx >=1.8
     - pillow >=2.1
+    - dask
 
 test:
   imports:


### PR DESCRIPTION
dask >= 0.5 is now a required dependency for scikit-image. Without it, setuptools complains:

```
>>> from pkg_resources import WorkingSet, Requirement
>>> w = WorkingSet()
>>> r = Requirement('scikit-image')
>>> w.resolve([r])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/tom/miniconda3/envs/scikit-image-defaults/lib/python2.7/site-packages/setuptools-27.2.0-py2.7.egg/pkg_resources/__init__.py", line 854, in resolve
pkg_resources.DistributionNotFound: The 'dask[array]>=0.5.0' distribution was not found and is required by scikit-image
```