### PR TITLE
nsis: Do note remove ${NSISDIR}/Contrib directory

### DIFF
--- a/nsis/bld.bat
+++ b/nsis/bld.bat
@@ -7,6 +7,5 @@ if errorlevel 1 exit 1
 %SYS_PYTHON% %RECIPE_DIR%\add_deps.py
 if errorlevel 1 exit 1
 
-rd /s /q %PREFIX%\NSIS\Contrib
 rd /s /q %PREFIX%\NSIS\Docs
 rd /s /q %PREFIX%\NSIS\Examples

--- a/nsis/meta.yaml
+++ b/nsis/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: 3.01
 
 build:
-  number: 2
+  number: 3
 
 about:
   home: http://nsis.sourceforge.net/Main_Page


### PR DESCRIPTION
It contains necessary runtime files (implementation of MUI2.nsi, ...)

Fixes gh-86