### PR TITLE
add jpeg 8* dependency to libnetcdf

### DIFF
--- a/libnetcdf/meta.yaml
+++ b/libnetcdf/meta.yaml
@@ -23,11 +23,13 @@ requirements:
     - hdf4 4.2.*
     - hdf5 1.8.17
     - zlib 1.2.*
+    - jpeg 8*
   run:
     - curl 7.49.*
     - hdf4 4.2.*
     - hdf5 1.8.17
     - zlib 1.2.*
+    - jpeg 8*
 
 test:
   commands:


### PR DESCRIPTION
This might just need a rebuild against jpeg 9, but either way it should have the dependency
version encoded in a requirement - if I install libnetcdf on its own then things work, but if
I install jpeg first (giving jpeg 9) then install libnetcdf, the shared library fails to open since
there are missing links to libjpeg.so.8