### PR TITLE
Fix hdf5 v1.8.17 tarball URL

### DIFF
--- a/hdf5/meta.yaml
+++ b/hdf5/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 source:
   fn: hdf5-1.8.17.tar.gz
-  url: http://www.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.8.17.tar.gz
+  url: https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8.17/src/hdf5-1.8.17.tar.gz
   md5: 7d572f8f3b798a628b8245af0391a0ca
 
 build:


### PR DESCRIPTION
The old URL throws a 404