### PR TITLE
Update conda-build-all to version 1.0.3

### DIFF
--- a/conda-build-all/meta.yaml
+++ b/conda-build-all/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: conda-build-all
-  version: 1.0.2
+  version: 1.0.3
 
 source:
   git_url: https://github.com/SciTools/conda-build-all.git
-  git_tag: v1.0.2
+  git_tag: v1.0.3
 
 build:
   entry_points:


### PR DESCRIPTION
The new version addresses this pull request:
https://github.com/SciTools/conda-build-all/pull/82