### PR TITLE
libconda: move pycosat to run requirements

### DIFF
--- a/libconda/meta.yaml
+++ b/libconda/meta.yaml
@@ -11,12 +11,11 @@ requirements:
     - python
   run:
     - python
+    - pycosat >=0.6.1
     - pyyaml
     - requests
 
 test:
-  requires:
-    - pycosat
   imports:
     - libconda
 


### PR DESCRIPTION
`pycosat` is not only a test but also run requirement.
Also added `pycosat >=0.6.1` version constraint as per `libconda`'s `setup.py`/`install_requires`.