### PR TITLE
constructor: remove pycosat, add pyyaml requirement

### DIFF
--- a/constructor/meta.yaml
+++ b/constructor/meta.yaml
@@ -16,7 +16,7 @@ requirements:
   run:
     - python
     - libconda
-    - pycosat >=0.6.1
+    - pyyaml
     - pillow >=3.1      [win]
     - nsis >=3.01       [win]
 


### PR DESCRIPTION
Removed dependency `pycosat` since this is not a direct requirement of `constructor` but one of `libconda`.
On the other hand `pyyaml` is a requirement for `constructor` and has been missing.