### PR TITLE
Upgrade to hdf5 1.8.18

### DIFF
--- a/hdf5/meta.yaml
+++ b/hdf5/meta.yaml
@@ -1,14 +1,14 @@
 package:
   name: hdf5
-  version: 1.8.17
+  version: 1.8.18
 
 source:
-  fn: hdf5-1.8.17.tar.gz
-  url: https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8.17/src/hdf5-1.8.17.tar.gz
-  md5: 7d572f8f3b798a628b8245af0391a0ca
+  fn: hdf5-1.8.18.tar.gz
+  url: http://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/hdf5-1.8.18/src/hdf5-1.8.18.tar.gz
+  md5: dd2148b740713ca0295442ec683d7b1c
 
 build:
-  number: 1
+  number: 2
   features:
     - vc9        [win and py27]
     - vc10       [win and py34]


### PR DESCRIPTION
A few CVEs were reported and fixed in hdf5 back in November 2016: http://blog.talosintelligence.com/2016/11/hdf5-vulns.html

The hdf5 release notes for that release are available here: https://support.hdfgroup.org/ftp/HDF5/current18/src/hdf5-1.8.18-RELEASE.txt

For more info, please see https://github.com/conda-forge/hdf5-feedstock/pull/68