### PR TITLE
Fixed error introduced in my previous PR

### DIFF
--- a/numexpr/site-mkl-win-32.cfg
+++ b/numexpr/site-mkl-win-32.cfg
@@ -1,4 +1,4 @@
 [mkl]
 include_dirs = @PREFIX@\Library\include
-library_dirs = @PREFIX@\Library\bin
+library_dirs = @PREFIX@\Library\lib
 mkl_libs = mkl_rt

--- a/numexpr/site-mkl-win-64.cfg
+++ b/numexpr/site-mkl-win-64.cfg
@@ -1,4 +1,4 @@
 [mkl]
 include_dirs = @PREFIX@\Library\include
-library_dirs = @PREFIX@\Library\bin
+library_dirs = @PREFIX@\Library\lib
 mkl_libs = mkl_rt


### PR DESCRIPTION
On Windows, library path should be `@PREFIX@\Library\lib`, since this is where ``*.lib`` files are located

Currently it was incorrectly set to ``@PREFIX@\Library\bin`` in [PR #53](https://github.com/ContinuumIO/anaconda-recipes/pull/53) which prevented building of NumExpr while linking to fixed interfaces dynamic library. 

For example, for linking with LP64 interface and sequential threading layer the folllowing line [should be used](https://software.intel.com/en-us/articles/intel-mkl-link-line-advisor)

```
mkl_libs = mkl_intel_lp64_dll, mkl_sequential_dll, mkl_core_dll
```

This would make numpy config code to look for ``mkl_intel_lp64_dll.lib`` in the library path, but it is not to be found in ``Library\bin``, so the build breaks.