### PR TITLE
Updated glue-core, glue-vispy-viewers and glueviz recipes

### DIFF
--- a/glue-core/meta.yaml
+++ b/glue-core/meta.yaml
@@ -1,12 +1,11 @@
 package:
   name: glue-core
-  version: 0.10.4
+  version: 0.11.0
 
 source:
-  fn: glue-core-0.10.4.tar.gz
-  url: https://pypi.io/packages/source/g/glue-core/glue-core-0.10.4.tar.gz
-  md5: def1af4db51dc6e0a79bb24539f4c633
-
+  fn: glue-core-0.11.0.tar.gz
+  url: https://pypi.io/packages/source/g/glue-core/glue-core-0.11.0.tar.gz
+  md5: 662aef48eb6bf4005aa433cea905c0a6
 
 build:
   entry_points:
@@ -28,7 +27,7 @@ requirements:
     - pandas >=0.14
     - astropy >=1.3
     - matplotlib >=1.4
-    - qtpy >=1.1
+    - qtpy >=1.1.1
     - ipython >=4.0
     - ipykernel
     - qtconsole

--- a/glue-vispy-viewers/meta.yaml
+++ b/glue-vispy-viewers/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: glue-vispy-viewers
-  version: 0.7.2
+  version: 0.8
 
 source:
-  fn: glue-vispy-viewers-0.7.2.tar.gz
-  url: https://pypi.io/packages/source/g/glue-vispy-viewers/glue-vispy-viewers-0.7.2.tar.gz
-  md5: 58cd60967ed1b80b965b0627b2d3bd77
+  fn: glue-vispy-viewers-0.8.tar.gz
+  url: https://pypi.io/packages/source/g/glue-vispy-viewers/glue-vispy-viewers-0.8.tar.gz
+  md5: 86134446dc50b5060f0ae8563e0fe677
 
 requirements:
   build:
@@ -15,7 +15,7 @@ requirements:
     - python
     - numpy
     - pyopengl
-    - glue-core >=0.10
+    - glue-core >=0.11
     - qtpy
     - scipy
     - astropy >=1.1

--- a/glueviz/meta.yaml
+++ b/glueviz/meta.yaml
@@ -4,12 +4,12 @@
 
 package:
   name: glueviz
-  version: 0.10.4
+  version: 0.11.0
 
 source:
-  fn: glueviz-0.10.4.tar.gz
-  url: https://pypi.io/packages/source/g/glueviz/glueviz-0.10.4.tar.gz
-  md5: 94f1774e3c379403966ca217bbe36d7a
+  fn: glueviz-0.11.0.tar.gz
+  url: https://pypi.io/packages/source/g/glueviz/glueviz-0.11.0.tar.gz
+  md5: 03954cd633bd7be25472d529034cb8fb
 
 requirements:
   build:
@@ -17,8 +17,8 @@ requirements:
     - setuptools
   run:
     - python
-    - glue-core >=0.10.4             [not win]
-    - glue-vispy-viewers >=0.7.2
+    - glue-core >=0.11             [not win]
+    - glue-vispy-viewers >=0.8
 
 app:
   entry: glue


### PR DESCRIPTION
These should be build in the following order: glue-core, glue-vispy-viewers, then glueviz

There are some ``[not win]`` which I am not sure if they are still needed.