### PR TITLE
Update mpich2 to use the cross compilation toolchain.

### DIFF
--- a/mpich2/build.sh
+++ b/mpich2/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-./configure --enable-shared --prefix=$PREFIX
+./configure --enable-shared --prefix=$PREFIX "F77=$FC" "FCFLAGS=$FFLAGS"
 make
 make install
 

--- a/mpich2/meta.yaml
+++ b/mpich2/meta.yaml
@@ -1,6 +1,3 @@
-# This is legacy recipe, which has not been tested using conda-build.
-# See: https://github.com/ContinuumIO/anaconda-recipes/blob/master/LEGACY.md
-
 package:
   name: mpich2
   version: 1.4.1p1
@@ -8,6 +5,18 @@ package:
 source:
   fn: mpich2-1.4.1p1.tar.gz
   md5: b470666749bcb4a0449a072a18e2c204
+  url: http://www.mpich.org/static/downloads/1.4.1p1/mpich2-1.4.1p1.tar.gz
+
+build:
+  detect_binary_files_with_prefix : True
+  number: 1
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ compiler('fortran') }}
+    - libgcc-ng
 
 about:
   home: http://www.mpich.org/


### PR DESCRIPTION
This probably depends on
https://github.com/ContinuumIO/anaconda-issues/issues/6696

After manually removed -fopenmp from the flags it compiled and I checked

mpi{cc, cxx, c++, f77, f90} --version

gave the correct compilers for cross compilation.