### PR TITLE
Update jupyter_mac.command

### DIFF
--- a/notebook/jupyter_mac.command
+++ b/notebook/jupyter_mac.command
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 DIR=$(dirname $0)
 
 $DIR/jupyter-notebook


### PR DESCRIPTION
For those who don't use bash as their default shell in Terminal, this file does not work (e.g. fish shell). Explicitly specifying the shell corrects this.