### PR TITLE
Add jupyter bundlerextension to entrypoints and test commands

### DIFF
--- a/notebook/meta.yaml
+++ b/notebook/meta.yaml
@@ -12,6 +12,7 @@ build:
     - jupyter-notebook = notebook.notebookapp:main
     - jupyter-nbextension = notebook.nbextensions:main
     - jupyter-serverextension = notebook.serverextensions:main
+    - jupyter-bundlerextension = notebook.bundler.bundlerextensions:main
 
 requirements:
   build:
@@ -46,6 +47,7 @@ test:
     - jupyter-notebook -h
     - jupyter-nbextension -h
     - jupyter-serverextension -h
+    - jupyter-bundlerextension -h
   imports:
     - notebook
 


### PR DESCRIPTION
I discovered recently that the command/script jupyter bundlerextension is not available or does not work when using a windows machine and the package is installed from anaconda or conda-forge channel.
I build this locally on my windows machine and it seems to work afterwards. So maybe this issue is related to the built process?

However I've added the command/script to the entry points and test commands to be able to see if the build fails.

As shown in [https://github.com/conda-forge/notebook-feedstock/pull/24](https://github.com/conda-forge/notebook-feedstock/pull/24) it works after adding these two lines.